### PR TITLE
Vpcendpoints

### DIFF
--- a/pcluster/pcluster_stack.py
+++ b/pcluster/pcluster_stack.py
@@ -24,7 +24,7 @@ class PclusterStack(cdk.Stack):
         super().__init__(scope, id, **kwargs)
 
         # S3 URI for Config file
-        config = cdk.CfnParameter(self, 'ConfigS3URI', description='Set a custom parallelcluster config file.', default='s3://notearshpc-quickstart/config.ini')
+        config = cdk.CfnParameter(self, 'ConfigS3URI', description='Set a custom parallelcluster config file.', default='https://notearshpc-quickstart.s3.amazonaws.com/config.ini')
 
         # Password
         password = cdk.CfnParameter(self, 'UserPasswordParameter', description='Set a password for the hpc-quickstart user', no_echo=True)

--- a/pcluster/pcluster_stack.py
+++ b/pcluster/pcluster_stack.py
@@ -30,7 +30,6 @@ class PclusterStack(cdk.Stack):
         password = cdk.CfnParameter(self, 'UserPasswordParameter', description='Set a password for the hpc-quickstart user', no_echo=True)
 
         # create a VPC
-        # https://docs.aws.amazon.com/cdk/api/latest/python/aws_cdk.aws_ec2.README.html#vpc-endpoints
         vpc = ec2.Vpc(self, 'VPC', cidr='10.0.0.0/20',
                       gateway_endpoints={
                           "S3": ec2.GatewayVpcEndpointOptions(
@@ -41,10 +40,6 @@ class PclusterStack(cdk.Stack):
                           )
                       },
                       max_azs=99)
-        # Add an interface endpoint
-        #vpc.add_interface_endpoint("EcrDockerEndpoint", {
-        #    "service": ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER
-        #})
 
         # create a private and public subnet per vpc
         selection = vpc.select_subnets(

--- a/pcluster/pcluster_stack.py
+++ b/pcluster/pcluster_stack.py
@@ -30,7 +30,21 @@ class PclusterStack(cdk.Stack):
         password = cdk.CfnParameter(self, 'UserPasswordParameter', description='Set a password for the hpc-quickstart user', no_echo=True)
 
         # create a VPC
-        vpc = ec2.Vpc(self, 'VPC', cidr='10.0.0.0/20', max_azs=99)
+        # https://docs.aws.amazon.com/cdk/api/latest/python/aws_cdk.aws_ec2.README.html#vpc-endpoints
+        vpc = ec2.Vpc(self, 'VPC', cidr='10.0.0.0/20',
+                      gateway_endpoints={
+                          "S3": ec2.GatewayVpcEndpointOptions(
+                              service=ec2.GatewayVpcEndpointAwsService.S3
+                          ),
+                          "DynamoDB": ec2.GatewayVpcEndpointOptions(
+                              service=ec2.GatewayVpcEndpointAwsService.DYNAMODB
+                          )
+                      },
+                      max_azs=99)
+        # Add an interface endpoint
+        #vpc.add_interface_endpoint("EcrDockerEndpoint", {
+        #    "service": ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER
+        #})
 
         # create a private and public subnet per vpc
         selection = vpc.select_subnets(

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -68,10 +68,21 @@ cat <<\WELCOME > ~/Welcome.txt
 WELCOME
 
 sudo cp ~/Welcome.txt /etc/motd
+echo 'cat /etc/motd' >> ~/.bash_profile
 
 # Fetch the config file from S3 and substitute variables
 mkdir -p ~/.parallelcluster
-aws s3 cp ${config} /tmp/config.ini --quiet
+
+echo "Pulling Config: ${config}"
+case "${config}" in
+    s3://*)
+        aws s3 cp ${config} /tmp/config.ini --quiet;;
+    http://*|https://*)
+        wget ${config} -O /tmp/config.ini -o /tmp/BOOTSTRAP.wget;;
+    *)
+        echo "Unknown/Unsupported post_install_script URI"
+        ;;
+esac
 envsubst < /tmp/config.ini > ~/.parallelcluster/config
 
 . ~/.bashrc


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added vpc gateway endpoints to the private subnets to give compute instances direct access to S3 without traversing natgateway. Patched bootstrap.sh to support http(s):// urls and s3:// uri specified by ConfigS3uri. I also updated the default ConfigS3uri to be https:// for users to access our base config. Lastly, I added “cat /etc/motd” to the cloud9 bash_profile  so we get the ascii art message whenever a new *login* terminal is launched on cloud9.

To confirm gateways function as expected: 

```
pcluster ssh hpc-cluster
salloc -N 1 
ssh (compute_node_ip)
```
Do this before and after deleting the NATGateway from your PublicSubnet: 
```
curl https://amazon.com
aws configure
# no access key
# no secret key
# specify region
# json format
aws s3 ls 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
