### PR TITLE
Move config file to ~/environment directory and cleanup config

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -46,7 +46,7 @@ alias pssh="pcluster ssh"
 EOF
 
 # Welcome message
-cat <<\WELCOME > ~/Welcome.txt
+cat <<\WELCOME > ~/environment/Welcome.txt
   _   _         _______                     _____ _           _
  | \ | |       |__   __|                   / ____| |         | |
  |  \| | ___      | | ___  __ _ _ __ ___  | |    | |_   _ ___| |_ ___ _ __
@@ -67,7 +67,7 @@ cat <<\WELCOME > ~/Welcome.txt
  $ pcluster dcv connect hpc-cluster
 WELCOME
 
-sudo cp ~/Welcome.txt /etc/motd
+sudo cp ~/environment/Welcome.txt /etc/motd
 echo 'cat /etc/motd' >> ~/.bash_profile
 
 # Fetch the config file from S3 and substitute variables
@@ -83,7 +83,13 @@ case "${config}" in
         echo "Unknown/Unsupported post_install_script URI"
         ;;
 esac
-envsubst < /tmp/config.ini > ~/.parallelcluster/config
+envsubst < /tmp/config.ini > ~/environment/config.ini
+
+# change default config file
+cat <<\EOF >> ~/.bashrc
+# Set default config file to be the in Cloud9 environment
+export AWS_PCLUSTER_CONFIG_FILE=~/environment/config.ini
+EOF
 
 . ~/.bashrc
 . /etc/profile

--- a/scripts/config.ini
+++ b/scripts/config.ini
@@ -35,9 +35,6 @@ cw_log_settings = cw-logs
 volume_size = 500
 shared_dir = /shared
 
-[dcv mydcv]
-enable = master
-
 [fsx fsx-scratch2]
 shared_dir = /scratch
 storage_capacity = 1200


### PR DESCRIPTION
This allows users to edit the config file directly from Cloud9 IDE instead of having to use a CLI editor. Also supports syntax highlighting with the .ini extension.

The **mydcv** section was un-unsed in the config. I removed it.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
